### PR TITLE
parts staff size

### DIFF
--- a/LilyPond-Engraving-Quickstart/music/parts/instrument_library/resources/books/bundle_books_instrument_library.ily
+++ b/LilyPond-Engraving-Quickstart/music/parts/instrument_library/resources/books/bundle_books_instrument_library.ily
@@ -5,6 +5,14 @@
 
 \version "2.24.1"
 
+% Staff size for parts
+  % LilyPond Standard staff size = 20. See table with recommendations for various sizes: http://lilypond.org/doc/v2.24/Documentation/notation/setting-the-staff-size
+  % That said, size 16.8 is a nice starting point for parts
+    #(set-global-staff-size 16.8) 
+  
+  % House fonts need to be restated after changing the staff size
+    \include "../../../../../resources/housefonts.ily"
+
 % Include all books you wish to print here
   \include "woodwinds/book_piccolo.ily"
   \include "woodwinds/book_flute.ily"

--- a/LilyPond-Engraving-Quickstart/music/parts/instrument_library/unsorted/harp.ily
+++ b/LilyPond-Engraving-Quickstart/music/parts/instrument_library/unsorted/harp.ily
@@ -35,9 +35,11 @@
   part_harp_part = \new PianoStaff {
     <<
       \new Staff = "staff_harp_upper" \with {
+        \magnifyStaff #15/17
         midiInstrument = "orchestral harp"
       } { \clef treble << \removeWithTag #'score \global \removeWithTag #'score \notes_harp_upper >> } 
       \new Staff = "staff_harp_lower" \with {
+        \magnifyStaff #15/17
         midiInstrument = "orchestral harp"
       } { \clef bass << \removeWithTag #'part \global \removeWithTag #'part \notes_harp_lower >> }
     >>

--- a/LilyPond-Engraving-Quickstart/music/parts/instrument_library/unsorted/piano.ily
+++ b/LilyPond-Engraving-Quickstart/music/parts/instrument_library/unsorted/piano.ily
@@ -35,9 +35,11 @@
   part_piano_part = \new PianoStaff {
     <<
       \new Staff = "staff_piano_upper" \with {
+        \magnifyStaff #15/17
         midiInstrument = "acoustic grand"
       } { \clef treble << \removeWithTag #'score \global \removeWithTag #'score \notes_piano_upper >> } 
       \new Staff = "staff_piano_lower" \with {
+        \magnifyStaff #15/17
         midiInstrument = "acoustic grand"
       } { \clef bass << \removeWithTag #'part \global \removeWithTag #'part \notes_piano_lower >> }
     >>


### PR DESCRIPTION
Staff size for parts can now be set in music/parts/instrument_library/resources/bundle_books_instrument_library.ily. (Easily accessible via new_song.ly).